### PR TITLE
Fix/add point 3 11

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,7 +343,6 @@ GEM
 PLATFORMS
   arm64-darwin-21
   x86_64-darwin-21
-  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,6 +343,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   x86_64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -25,7 +25,7 @@ class TasksController < ApplicationController
     @tasks = Task.where(user_id: current_user.id).paginate(page: params[:page])
     @task = Task.find_by(id: params[:id])
   end
-  
+
   def new
     @task = Task.new
   end
@@ -39,7 +39,7 @@ class TasksController < ApplicationController
     @task = Task.find(params[:id])
     if @task.status == '実行中' && Time.now < @task.deadline_at
       @task.status = '成功'
-      
+
       # 問題の箇所１
       # タスクに紐づく全ての応援費の合計を算出
       support_fees = 0
@@ -68,7 +68,7 @@ class TasksController < ApplicationController
           support_user = User.find(support_user_id)
           if support.present?
             support_user.dice_point = support_user.dice_point.present? ? support_user.dice_point + support.support_fee : support.support_fee
-          end            
+          end
         end
         support_user.save!
       end
@@ -87,7 +87,7 @@ class TasksController < ApplicationController
     redirect_to task_path(@task[:id])
     flash[:notice] = "ダイスをもらえる権利に立候補しました。"
 
-    else 
+    else
       "立候補できません。"
       redirect_to tasks_path(@task[:id])
     end
@@ -95,9 +95,13 @@ class TasksController < ApplicationController
 
   def last_message
     @task = Task.find(params[:id])
-    redirect_to task_path(@task[:id])
   end
 
+  def update_last_message
+    @task = Task.find(params[:id])
+    @task.update!(last_message: params[:last_message])
+    redirect_to task_path(@task[:id])
+  end
 end
 
 
@@ -105,7 +109,7 @@ private
 
   def task_params
     params.require(:task).permit(:content,:bet_user_id,:user_id,
-                                :deadline_at,:amount_bet,:status, 
+                                :deadline_at,:amount_bet,:status,
                                 :last_time_at,:last_message,:image)
   end
 

--- a/app/views/tasks/_form2.html.erb
+++ b/app/views/tasks/_form2.html.erb
@@ -1,8 +1,8 @@
-<%= form_with url: {controller: 'tasks', action: 'last_message' } do  |f| %>
+<%= form_with url: tasks_last_message_path(task), method: :patch, local: true do |f| %>
   <%= f.label :タスクを終えて一言 %>
   <%= f.text_field :last_message, class: 'form-control' %>
 
-  
+
   <%= f.submit yield(:button_text), class: "btn btn-primary" %>
 
 <% end %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -15,9 +15,9 @@
           <%= link_to '応援', new_task_support_path(task_id: @task.id), method: :get %>
           <%= button_to '立候補する', tasks_candidate_path(@task),method: :patch, class:'btn btn-primary' %>
         <% else %>
-         
+
           <%# コメント：成功か失敗を表示する %>
-          
+
           <%= "このタスクは" %>
           <%= @task.last_time_at %><br>
           <%= @task.status %>
@@ -28,7 +28,7 @@
           <%= @task.last_message %>
           <% end %>
         <% end %><br>
-        
+
         <% @supports.each do |support| %>
           <%= support.comment %>
           <%= support.support_fee %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,11 +15,12 @@ Rails.application.routes.draw do
   get "users/ranking", to: "users#ranking"
   get "tasks/index"
   get "tasks/:id/last_message", to: "tasks#last_message",  as: 'tasks_last_message'
+  patch "tasks/:id/last_message", to: "tasks#update_last_message"
   patch 'tasks/:id/status_run/', to: "tasks#status_run", as: 'task_status_run'
   get "supports/new"
   get "supports/tasks/:id", to: "supports#index", as: 'supports_index'
   patch 'tasks/candidate/:id', to: "tasks#candidate", as: 'tasks_candidate'
-  
+
   resources :users
   resources :account_activations, only: [:edit]
   resources :password_resets,     only: [:new, :create, :edit, :update]


### PR DESCRIPTION
- routesにlast_messge更新用のAPI（patch）を追加し、update_last_messageアクションを追加した
- それに伴い、form_withの記述を修正した
- 既存のlast_messageアクションは、フォームへの遷移のみ行うようにした(def last_messageを参照ください）
- update_last_messageの処理は、taskのlast_messageの更新と、task詳細へのリダイレクト処理を行う形とした